### PR TITLE
Update sonata_seo.yml

### DIFF
--- a/app/config/sonata/sonata_seo.yml
+++ b/app/config/sonata/sonata_seo.yml
@@ -2,10 +2,9 @@
 # more information can be found here http://sonata-project.org/bundles/page
 #
 sonata_seo:
-    page:
-      default:          sonata.seo.page.default
     encoding:             UTF-8
     page:
+        default:          sonata.seo.page.default
         title:            cms-sandbox
         metas:
             name:


### PR DESCRIPTION
Fixed redundant configuration key "page" under "sonata_seo" key. Causing the other config to be ignored.
